### PR TITLE
Allow specifying config_file and node_name

### DIFF
--- a/lex_node/launch/lex.launch.py
+++ b/lex_node/launch/lex.launch.py
@@ -39,9 +39,6 @@ def generate_launch_description():
             node_executable='lex_node',
             node_name=LaunchConfiguration('node_name'),
             parameters=[LaunchConfiguration('config_file')],
-            output='screen',
-            additional_env={
-                'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED': '1'
-            },
+            output='screen'
         ),
     ])

--- a/lex_node/launch/lex.launch.py
+++ b/lex_node/launch/lex.launch.py
@@ -18,15 +18,30 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    # TODO(wjwwood): Use a substitution to find share directory once this is implemented in launch
-    parameters_file_path = os.path.join(get_package_share_directory('lex_node'),
+    config_file_path = os.path.join(get_package_share_directory('lex_node'),
                                         'config', 'sample_configuration.yaml')
     return LaunchDescription([
-        Node(package='lex_node',
-             node_executable='lex_node',
-             parameters=[parameters_file_path],
-             output='screen'),
+        DeclareLaunchArgument(
+            name='node_name',
+            default_value='lex_node'
+        ),
+        DeclareLaunchArgument(
+            name='config_file',
+            default_value=config_file_path
+        ),
+        Node(
+            package='lex_node',
+            node_executable='lex_node',
+            node_name=LaunchConfiguration('node_name'),
+            parameters=[LaunchConfiguration('config_file')],
+            output='screen',
+            additional_env={
+                'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED': '1'
+            },
+        ),
     ])

--- a/lex_node/src/main.cpp
+++ b/lex_node/src/main.cpp
@@ -49,6 +49,9 @@ void shutdown(const Aws::SDKOptions & options)
  */
 int main(int argc, char * argv[])
 {
+
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions node_options;


### PR DESCRIPTION
- Add parameters to allow the user of this node to specify their own
config file and node name.
- Add env var to make logging output stream to terminal instead of buffering. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
