### PR TITLE
Allow setting region or user_id from env var or param

### DIFF
--- a/lex_node/package.xml
+++ b/lex_node/package.xml
@@ -23,6 +23,7 @@
     <exec_depend>rclcpp</exec_depend>
     <exec_depend>lex_common_msgs</exec_depend>
     <exec_depend>aws_ros2_common</exec_depend>
+    <exec_depend>python3-yaml</exec_depend>
 
     <test_depend>ament_cmake_gmock</test_depend>
     <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
- Allow launching this node with a specific aws region or user_id by
setting ROS_AWS_REGION or LEX_USER_ID or passing them as parameters to
the launch file.

Order of parameter overrides is:
- Environment variable
- Parameter passed to the launch file
- Value in sample_configuration.yaml

## Testing

- Tested running this node with the env var for region set and it worked
- Tested including this node in VoiceInteraction sample application and passing param for region and it worked.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
